### PR TITLE
README constain 'Dependencies' that are explicit and implicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,16 @@ This repository contains Ruby API for utilizing [TensorFlow](https://github.com/
 
 ## Dependencies
 
+### Explicit Install
+
 - [Bazel](http://www.bazel.io/docs/install.html)
 - [TensorFlow](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/g3doc/get_started/os_setup.md)
+- [Swig](http://www.swig.org/download.html)
+
+### Implicit Install (No Action Required)
+
 - [Google-Protoc gem](https://github.com/google/protobuf/tree/master/ruby) ( for installation do  ```gem install google-protoc --pre ```)
 - [Protobuf](https://github.com/google/protobuf)
-- [Swig](http://www.swig.org/download.html)
 
 ## Installation
 


### PR DESCRIPTION
Some dependencies need to be explicitly installed by users while
others are implicitly pulled in during installation of
explicitly intalled dependencies.

Split this into 'Explicit' and 'Implicit' sections in 'Dependencies'