### PR TITLE
Updated path to extconf.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Clone and install this Ruby API:
 ```
 git clone https://github.com/Arafatk/ruby-tensorflow.git
 cd ruby-tensorflow
-cd ext
+cd ext/sciruby/tensorflow_c
 ruby extconf.rb
 make
 make install # Creates ../lib/ruby/site_ruby/X.X.X/<arch>/tf/Tensorflow.bundle (.so Linux)


### PR DESCRIPTION
It seems the ext directory was replaced by a more appropriate directory structure. I've updated the README accordingly.