### PR TITLE
Remove unnecessary rvm conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains Ruby API for utilizing [TensorFlow](https://github.com/
 [![Code Climate](https://codeclimate.com/github/Arafatk/tensorflow.rb/badges/gpa.svg)](https://codeclimate.com/github/Arafatk/tensorflow.rb)
 [![Join the chat at https://gitter.im/Arafatk/tensorflow.rb](https://badges.gitter.im/Arafatk/tensorflow.rb.svg)](https://gitter.im/Arafatk/tensorflow.rb?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
+## Description
 ## Docker
 
 Launch:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,12 @@ This repository contains Ruby API for utilizing [TensorFlow](https://github.com/
 [![Code Climate](https://codeclimate.com/github/Arafatk/tensorflow.rb/badges/gpa.svg)](https://codeclimate.com/github/Arafatk/tensorflow.rb)
 [![Join the chat at https://gitter.im/Arafatk/tensorflow.rb](https://badges.gitter.im/Arafatk/tensorflow.rb.svg)](https://gitter.im/Arafatk/tensorflow.rb?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-## Description
+## Documentation
+Everything is at [RubyDoc](http://www.rubydoc.info/github/Arafatk/tensorflow.rb).   
+You can also generate docs by 
+```bundle exec rake doc```.
+
+
 ## Docker
 
 Launch:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ cd ext
 ruby extconf.rb
 make
 make install # Creates ../lib/ruby/site_ruby/X.X.X/<arch>/tf/Tensorflow.bundle (.so Linux)
-             # Creates ${GEM_HOME}/gems/tensorflow-0.0.1/lib/tf/Tensorflow.bundle (.so with rvm)
 cd ./..
 bundle exec rake install
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains Ruby API for utilizing [TensorFlow](https://github.com/
 [![Join the chat at https://gitter.im/Arafatk/tensorflow.rb](https://badges.gitter.im/Arafatk/tensorflow.rb.svg)](https://gitter.im/Arafatk/tensorflow.rb?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Documentation
-Everything is at [RubyDoc](http://www.rubydoc.info/github/Arafatk/tensorflow.rb).   
+Everything is at [RubyDoc](http://www.rubydoc.info/github/Arafatk/tensorflow.rb).
 You can also generate docs by 
 ```bundle exec rake doc```.
 

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ require 'yard'
 RSpec::Core::RakeTask.new(:spec)
 
 YARD::Rake::YardocTask.new(:doc) do |t|
-  t.files = ['lib/*.rb']
+  t.files = ['lib/*.rb', 'lib/**/*.rb']
 end
 
 task :default => :spec

--- a/lib/tensorflow.rb
+++ b/lib/tensorflow.rb
@@ -1,10 +1,6 @@
 require 'tensorflow/core/framework/tensor'
 require 'tensorflow/core/framework/graph'
-if ENV['rvm_version'].nil?
-  require 'sciruby/Tensorflow'
-else
-  require "#{ENV['GEM_HOME']}/gems/tensorflow-0.0.1/lib/sciruby/Tensorflow"
-end
+require 'sciruby/Tensorflow'
 require 'tensorflow/tensor'
 require 'tensorflow/graph'
 require 'tensorflow/session'


### PR DESCRIPTION
Code for 'handling rvm install' that were previously removed since they were unnecessary after we cleaned up and restructured  'ext/' directory, was accidentally re-introduced during one of the merges?
Removing them again to keep the codebase clean.