### PR TITLE
Add files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+ext/sciruby/tensorflow_c/Makefile
+ext/sciruby/tensorflow_c/*.so
+ext/sciruby/tensorflow_c/*.cxx
+ext/sciruby/tensorflow_c/*.o
+pkg/


### PR DESCRIPTION
There are several files in the ext/ and pkg/ directories which are intermediate
artifacts and should not be committed to the repository. Some were temporarily
removed in e0759f8 but this ensures that they don't get added back.