### PR TITLE
refactor Session for readability

### DIFF
--- a/lib/tensorflow/session.rb
+++ b/lib/tensorflow/session.rb
@@ -1,11 +1,11 @@
 # A class for running TensorFlow operations.
-# A Session object encapsulates the environment in which Operation objects are executed, and Tensor objects are evaluated. 
+# A Session object encapsulates the environment in which Operation objects are executed, and Tensor objects are evaluated.
 # A Session instance lets a caller drive a TensorFlow graph computation.
 # When a Session is created with a given target, a new Session object is bound to the
 # universe of resources specified by that target. Those resources are available to this
 # session to perform computation described in the GraphDef. After extending the session
-# with a graph, the caller uses the Run() API to perform the computation and potentially 
-# fetch outputs as Tensors. Protocol buffer exposes various configuration options for a session. The Op definations are stored in ops.pb file. 
+# with a graph, the caller uses the Run() API to perform the computation and potentially
+# fetch outputs as Tensors. Protocol buffer exposes various configuration options for a session. The Op definations are stored in ops.pb file.
 # Official documentation of {session}[https://www.tensorflow.org/versions/r0.9/api_docs/python/client.html#Session] and {Operation}[https://www.tensorflow.org/versions/r0.9/api_docs/python/framework.html#Operation].
 class Tensorflow::Session
   attr_accessor :status, :ops, :session, :graph
@@ -14,7 +14,7 @@ class Tensorflow::Session
   # @!attribute ops
   #  Nodes in the graph are called ops (short for operations). An op takes zero or more Tensors, performs some computation, and produces zero or more Tensors.
   # @!attribute graph
-  # A TensorFlow graph is a description of computations. To compute anything, a graph must be launched in a Session. A Session places the graph ops and provides methods to execute them. 
+  # A TensorFlow graph is a description of computations. To compute anything, a graph must be launched in a Session. A Session places the graph ops and provides methods to execute them.
 
   def initialize()
   	self.status = Tensorflow::TF_NewStatus()
@@ -23,7 +23,138 @@ class Tensorflow::Session
   end
 
   #
-  # Converts a give ruby array to C array (using SWIG) by detecting the data type automatically. 
+  # Runs a session on a given input.
+  # * *Returns* :
+  #   - nil
+  #
+  def run(inputs, outputs, targets)
+    input_names, input_values = initialize_inputs(inputs)
+    output_names, output_values = initialize_outputs(outputs)
+    target_names = initialize_targets(targets)
+
+   	status = Tensorflow::TF_NewStatus()
+	  Tensorflow::TF_Run_wrapper(self.session, input_names, input_values, output_names, output_values, target_names, self.status)
+    raise ("Incorrect specifications passed.")  if Tensorflow::TF_GetCode(status) != Tensorflow::TF_OK
+
+    output_array = []
+
+    output_values.each do |value|
+      converted_value = convert_value_for_output_array(value)
+      output_array.push(converted_value)
+    end
+
+    output_array
+  end
+
+  def extend_graph(graph)
+  	self.status = Tensorflow::TF_NewStatus()
+  	Tensorflow::TF_ExtendGraph(self.session, graph_def_to_c_array(graph.graph_def_raw), graph.graph_def_raw.length, self.status)
+  	self.graph = graph
+  end
+
+  private
+
+  def initialize_inputs(inputs)
+    input_names = Tensorflow::String_Vector.new
+    input_values = Tensorflow::Tensor_Vector.new
+    if inputs != nil
+      inputs.each do |key, value|
+        input_values.push(value)
+        input_names.push(key)
+      end
+    end
+
+    return input_names, input_values
+  end
+
+  def initialize_outputs(outputs)
+    output_names = Tensorflow::String_Vector.new
+    outputs.each do |name|
+      output_names.push(name)
+    end
+
+    output_values = Tensorflow::Tensor_Vector.new
+
+    return output_names, output_values
+  end
+
+  def initialize_targets(targets)
+    target_names = Tensorflow::String_Vector.new
+    if targets != nil
+      targets.each do |name|
+        target_names.push(name)
+      end
+    end
+
+    target_names
+  end
+
+  def convert_value_for_output_array(value)
+    size = Tensorflow::tensor_size(value)
+    c_array = construct_c_array(value, size)
+    length_by_dimension = length_by_dimension(value)
+    arrange_into_dimensions(c_array, size, length_by_dimension)
+  end
+
+  # Returns an array containing the length of the tensor in each dimension
+  def length_by_dimension(value)
+    num_dimensions = Tensorflow::TF_NumDims(value)
+    result = []
+
+    (0..num_dimensions - 1).each_with_object([]) do |dimension, array|
+      array.push(Tensorflow::TF_Dim(value, dimension))
+    end
+  end
+
+  def construct_c_array(value, size)
+    type = Tensorflow::TF_TensorType(value)
+
+    case type
+    when Tensorflow::TF_DOUBLE
+      c_array = Tensorflow::Double.new(size)
+      Tensorflow::double_reader(value, c_array, size)
+    when Tensorflow::TF_INT64
+      c_array = Tensorflow::Long_long.new(size)
+      Tensorflow::long_long_reader(value, c_array, size)
+    when Tensorflow::TF_INT32
+      c_array = Tensorflow::Int.new(size)
+      Tensorflow::int_reader(value, c_array, size)
+    when Tensorflow::TF_COMPLEX128
+      c_array = Tensorflow::complex_reader(value)
+    else
+      raise "Data type not supported."
+    end
+
+    c_array
+  end
+
+  # Arrange a flat array into an array of arrays organized by tensor dimensions
+  def arrange_into_dimensions(c_array, size, length_by_dimension)
+    output = []
+    (0..size - 1).each do |j|
+       output.push(c_array[j])
+    end
+
+    length_by_dimension.reverse!
+    (0..length_by_dimension.length - 2).each do |dim|
+      all_dimensions = []
+      one_dimension = []
+      output.each do |val|
+        one_dimension.push(val)
+        if one_dimension.length == length_by_dimension[dim]
+          all_dimensions.push(one_dimension)
+          one_dimension = []
+        end
+      end
+
+      output = all_dimensions
+    end
+
+    output
+  end
+
+  #
+  # Converts a give ruby array to C array (using SWIG) by detecting the data type automatically.
   # Design decision needs to be made regarding this so the all the data types are supported.
   # Currently Integer(Ruby) is converted to long long(C) and Float(Ruby) is converted double(C).
   #
@@ -38,87 +169,4 @@ class Tensorflow::Session
    c_array
   end
 
-  #
-  # Runs a session on a given input.
-  # * *Returns* :
-  #   - nil
-  #
-  def run(inputs, outputs, targets)
-  	inputNames = Tensorflow::String_Vector.new
-  	inputValues = Tensorflow::Tensor_Vector.new
-    if inputs != nil
-  	  inputs.each do |key, value|
-  		  inputValues.push(value)
-  		  inputNames.push(key)
-  	  end
-    end
-
-  	outputNames = Tensorflow::String_Vector.new
-  	outputs.each do |name|
-  		outputNames.push(name)
-  	end
-
-  	targetNames = Tensorflow::String_Vector.new
-    if targets != nil
-  	  targets.each do |name|
-  		  targetNames.push(name)
-  	  end
-    end
-
-  	outputValues = Tensorflow::Tensor_Vector.new
-   	status = Tensorflow::TF_NewStatus()
-	  Tensorflow::TF_Run_wrapper(self.session , inputNames, inputValues, outputNames, outputValues, targetNames, self.status)
-    raise ("Incorrect specifications passed.")  if Tensorflow::TF_GetCode(status) != Tensorflow::TF_OK
-    output_array = []
-    (0..outputValues.size - 1).each do |i|
-      size = Tensorflow::tensor_size(outputValues[i])
-      type = Tensorflow::TF_TensorType(outputValues[i])
-
-      case type
-      when Tensorflow::TF_DOUBLE
-        c_array = Tensorflow::Double.new(size)
-        Tensorflow::double_reader(outputValues[i], c_array, size)
-      when Tensorflow::TF_INT64
-        c_array = Tensorflow::Long_long.new(size)
-        Tensorflow::long_long_reader(outputValues[i], c_array, size)
-      when Tensorflow::TF_INT32
-        c_array = Tensorflow::Int.new(size)
-        Tensorflow::int_reader(outputValues[i], c_array, size)
-      when Tensorflow::TF_COMPLEX128
-        c_array = Tensorflow::complex_reader(outputValues[i])
-      else
-        raise "Data type not supported."
-      end
-
-      num_dimensions = Tensorflow::TF_NumDims(outputValues[i])
-      out_dimension = []
-      (0..num_dimensions - 1).each do |j|
-         out_dimension.push(Tensorflow::TF_Dim(outputValues[i], j))
-      end
-      output = []
-      (0..size - 1).each do |j|
-         output.push(c_array[j])
-       end
-       out_dimension.reverse!
-       (0..out_dimension.length - 2).each do |k|
-          total_dim = output.length
-          dim_array = []
-          temp_array = []
-          (0..total_dim - 1).each do |ind|
-            temp_array.push(output[ind])
-            dim_array.push(temp_array) if (temp_array.length == out_dimension[k])
-            temp_array = []            if (temp_array.length == out_dimension[k])
-          end
-          output = dim_array
-       end
-       output_array.push(output)
-    end
-    output_array
-  end
-
-  def extend_graph(graph)
-  	self.status = Tensorflow::TF_NewStatus()
-  	Tensorflow::TF_ExtendGraph(self.session, graph_def_to_c_array(graph.graph_def_raw), graph.graph_def_raw.length, self.status)
-  	self.graph = graph
-  end
 end


### PR DESCRIPTION
As someone new to the project, I found `Session#run` quite difficult to follow.

This is an attempt at making it easier to understand for other developers, mainly by splitting it out into shorter methods with expressive names. This also now feels more typical of the Ruby style which tends to prefer short methods.

I confirmed that this doesn't break any unit tests. (thanks for writing those, very helpful for refactoring)

Some of these are subjective style things, so let me know what you think! Definitely open to feedback.