### PR TITLE
Ignoring Tensorflow.bundle that is produced on OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ ext/sciruby/tensorflow_c/Makefile
 ext/sciruby/tensorflow_c/*.so
 ext/sciruby/tensorflow_c/*.cxx
 ext/sciruby/tensorflow_c/*.o
+ext/sciruby/tensorflow_c/*.bundle
 .*.time
 pkg/
 .yardoc/


### PR DESCRIPTION
On OSX the compilation of the extension is producing a bundle artifact. I'd like to ignore it since we better not check this in.