### PR TITLE
Circle ci use prebuilt docker image

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,11 @@ machine:
   services:
     - docker
 
+general:
+  branches:
+    only:
+      - /circle_ci/
+
 dependencies:
   override:
     - docker info

--- a/circle.yml
+++ b/circle.yml
@@ -10,8 +10,8 @@ general:
 dependencies:
   override:
     - docker info
-    - docker build -t circleci/elasticsearch -f tools/docker/Dockerfile .
+    - docker build -t nethsix/ruby-tensorflow-ubuntu:0.0.1 -f tools/docker/Dockerfile .
 
 test:
   override:
-    - docker run -it bb0890c9b75f /bin/bash -l -c 'cd /repos/ruby-tensorflow && bundle exec rspec'
+    - docker run -it nethsix/ruby-tensorflow-ubuntu:0.0.1 /bin/bash -l -c 'cd /repos/ruby-tensorflow && bundle exec rspec'

--- a/circle.yml
+++ b/circle.yml
@@ -7,11 +7,12 @@ general:
     only:
       - /circle_ci/
 
-dependencies:
-  override:
-    - docker info
-    - docker build -t nethsix/ruby-tensorflow-ubuntu:0.0.1 -f tools/docker/Dockerfile .
+# dependencies:
+#   override:
+#     - docker info
+#     - docker build -t nethsix/ruby-tensorflow-ubuntu:0.0.1 -f tools/docker/Dockerfile .
 
 test:
   override:
-    - docker run -it nethsix/ruby-tensorflow-ubuntu:0.0.1 /bin/bash -l -c 'cd /repos/ruby-tensorflow && bundle exec rspec'
+#     - docker run -it nethsix/ruby-tensorflow-ubuntu:0.0.1 /bin/bash -l -c 'cd /repos/ruby-tensorflow && bundle exec rspec'
+     - docker run -it nethsix/ruby-tensorflow-ubuntu:0.0.1.a /bin/bash -l -c "cd /repos/ruby-tensorflow && git checkout master && git pull && bundle install && cd /repos/ruby-tensorflow/ext/sciruby/tensorflow_c && ruby extconf.rb && make && make install && cd /repos/ruby-tensorflow && bundle exec rake install && bundle exec rspec"

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,12 @@
+machine:
+  services:
+    - docker
+
+dependencies:
+  override:
+    - docker info
+    - docker build -t circleci/elasticsearch -f tools/docker/Dockerfile .
+
+test:
+  override:
+    - docker run -it bb0890c9b75f /bin/bash -l -c 'cd /repos/ruby-tensorflow && bundle exec rspec'

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,0 +1,67 @@
+FROM ubuntu:16.04
+MAINTAINER nethsix <nethsix@gmail.com>
+
+# Update apt
+RUN apt-get update
+
+# Basic utilities
+RUN apt-get install -y curl
+RUN apt-get install -y vim
+RUN apt-get install -y iputils-ping
+RUN apt-get install -y dnsutils
+RUN apt-get install -y gawk
+RUN apt-get install -y gnupg2
+
+# Required to get tensorflow, ruby-tensorflow, etc.
+RUN apt-get install -y git
+
+# Required for bazel
+RUN apt-get install -y openjdk-8-jdk
+RUN echo "deb http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
+RUN curl https://storage.googleapis.com/bazel-apt/doc/apt-key.pub.gpg | apt-key add -
+
+# Install bazel
+RUN apt-get update && apt-get install -y bazel
+RUN apt-get upgrade -y bazel
+
+# Install tensorflow
+RUN /bin/mkdir /repos
+RUN cd /repos && git clone --recurse-submodules https://github.com/tensorflow/tensorflow
+# For info about why '--jobs'
+# * https://github.com/tensorflow/tensorflow/issues/349
+# For why we use '--batch'
+# * https://github.com/bazelbuild/bazel/issues/418
+RUN cd /repos/tensorflow && bazel --batch build --jobs=10 //tensorflow:libtensorflow.so
+RUN cp /repos/tensorflow/bazel-bin/tensorflow/libtensorflow.so /usr/lib/
+
+# Required by ruby-tensorflow
+RUN apt-get install -y swig
+
+# Ruby stuff
+# NOTE: keys.gnupg.net is a redirection thus using DNS to resolve
+#       that within Docker failse
+RUN gpg --keyserver hkp://$(dig +short keys.gnupg.net | awk 'BEGIN { regex="^[0-9.]+$"; ip="" } { if (match($0, regex) && (ip == "")) { ip = $1 } } END { print ip }') --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+RUN curl -L https://get.rvm.io | bash -s stable
+RUN /bin/bash -l -c "rvm requirements"
+RUN /bin/bash -l -c "rvm install 2.2.4"
+# NOTE: Cannot find a good way to coordinate rvm and gem
+#       thus the belog gem install will end up installing bundler
+#       in systems
+# RUN /bin/bash -l -c "rvm gemset use ruby-2.2.4@global && gem install bundler --no-rdoc --no-ri"
+# Set ruby/gemset to be 2.2.4@global at '/' instead
+RUN cd / && /bin/bash -l -c "rvm --ruby-version use 2.2.4@global"
+RUN cd / && /bin/bash -l -c "gem install bundler --no-rdoc --no-ri"
+
+RUN echo 'source /etc/profile.d/rvm.sh' >> ~/.bashrc
+
+RUN /bin/bash -l -c "gem install bundle --no-rdoc --no-ri"
+RUN /bin/bash -l -c "rvm gemset create ruby-tensorflow"
+
+# Install ruby-tensorflow
+RUN cd /repos && git clone https://github.com/Arafatk/ruby-tensorflow.git
+RUN cd /repos/ruby-tensorflow && /bin/bash -l -c "rvm --ruby-version use 2.2.4@ruby-tensorflow"
+
+RUN cd /repos/ruby-tensorflow && /bin/bash -l -c "bundle install"
+
+RUN cd /repos/ruby-tensorflow/ext/sciruby/tensorflow_c && /bin/bash -l -c "ruby extconf.rb && make && make install"
+RUN cd /repos/ruby-tensorflow && /bin/bash -l -c "bundle exec rake install"

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -31,7 +31,7 @@ RUN cd /repos && git clone --recurse-submodules https://github.com/tensorflow/te
 # * https://github.com/tensorflow/tensorflow/issues/349
 # For why we use '--batch'
 # * https://github.com/bazelbuild/bazel/issues/418
-RUN cd /repos/tensorflow && bazel --batch build --jobs=10 //tensorflow:libtensorflow.so
+RUN cd /repos/tensorflow && bazel --batch build --jobs=10 --spawn_strategy=standalone --genrule_strategy=standalone //tensorflow:libtensorflow.so
 RUN cp /repos/tensorflow/bazel-bin/tensorflow/libtensorflow.so /usr/lib/
 
 # Required by ruby-tensorflow


### PR DESCRIPTION
* DON'T MERGE YET, instead:
  1. Please sign up for CircleCI (click 'Add' button on the top-right) when you have time here: https://github.com/integrations/circle-ci
  2. At the dashboard, select yourself
  3. Select ruby-tensorflow
  4. Look for this branch, and click on it
  5. Click 'rebuild' at the top
  6. Let us know in the comments if it was successful

* Notes:
  * Changed circle.yml to instruct CircleCI to use prebuilt docker image for building ruby-tensorflow and running specs
  * It now takes < 4 mins instead of ~45 mins to build and run specs
  * Auto-CI is still turned off since we're testing the flow
